### PR TITLE
use a neutered read-only raf for sending

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dat-cp",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3154,15 +3154,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3179,22 +3177,19 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3325,8 +3320,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3340,7 +3334,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3357,7 +3350,6 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3366,15 +3358,13 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3395,7 +3385,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3484,8 +3473,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3499,7 +3487,6 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3637,7 +3624,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dat-cp",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Dat Copy - remote file copy, powered by the dat protocol",
   "engines": {
     "node": ">=6.0.0"
@@ -54,7 +54,8 @@
     "hyperdrive": "^9.14.0",
     "multi-random-access": "^2.1.1",
     "random-access-file": "^2.0.1",
-    "random-access-memory": "^3.0.0"
+    "random-access-memory": "^3.0.0",
+    "random-access-storage": "^1.3.0"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/src/lib/raf-readonly.js
+++ b/src/lib/raf-readonly.js
@@ -1,0 +1,86 @@
+/*
+ * This is lifted pretty much directly from
+ * https://github.com/random-access-storage/random-access-file//blob/master/index.js
+ *
+ * The main differences are:
+ * - Removed a few things that are not relevant for my use case.
+ * - Neutered the write function in order to make access read only.
+ */
+var inherits = require('util').inherits
+var RandomAccess = require('random-access-storage')
+var fs = require('fs')
+var path = require('path')
+var constants = fs.constants || require('constants')
+
+var READONLY = constants.O_RDONLY
+
+module.exports = RandomAccessFile
+
+function RandomAccessFile (filename, opts = {}) {
+  if (!(this instanceof RandomAccessFile)) {
+    return new RandomAccessFile(filename, opts)
+  }
+  RandomAccess.call(this)
+
+  if (opts.directory) {
+    filename = path.join(opts.directory, filename)
+  }
+
+  this.filename = filename
+  this.fd = 0
+}
+
+inherits(RandomAccessFile, RandomAccess)
+
+RandomAccessFile.prototype._open = function (req) {
+  var self = this
+
+  fs.open(self.filename, READONLY, onopen)
+
+  function onopen (err, fd) {
+    if (err) {
+      return req.callback(err)
+    }
+
+    self.fd = fd
+    return req.callback(null)
+  }
+}
+
+RandomAccessFile.prototype._write = function (req) {
+  // Do nothing - we are writing files to archive that already exist on disk.
+  // If we don't specify this function then random-access-storage errors.
+  req.callback(null)
+}
+
+RandomAccessFile.prototype._read = function (req) {
+  var data = req.data || Buffer.allocUnsafe(req.size)
+  var fd = this.fd
+
+  if (!req.size) {
+    return process.nextTick(readEmpty, req)
+  }
+  fs.read(fd, data, 0, req.size, req.offset, onread)
+
+  function onread (err, read) {
+    if (err) {
+      return req.callback(err)
+    }
+    if (!read) {
+      return req.callback(new Error('Could not satisfy length'))
+    }
+
+    req.size -= read
+    req.offset += read
+
+    if (!req.size) {
+      return req.callback(null, data)
+    }
+
+    fs.read(fd, data, data.length - req.size, req.size, req.offset, onread)
+  }
+}
+
+function readEmpty (req) {
+  req.callback(null, Buffer.alloc(0))
+}

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -3,8 +3,8 @@
  * https://github.com/datproject/dat-storage/blob/master/index.js
  *
  * The main differences are:
- * - Removed a few things that are not relevant for my use case
- * - Changed it so that ram is used for everything other than the actual data
+ * - Removed a few things that are not relevant for my use case.
+ * - Changed it so that ram is used for everything other than the actual data.
  * - Use path provided as an opt on archive.createWriteStream to set the
  *   directory when instantiating raf for uploads. This allows you to add files
  *   to the archive that are not actually within the dir of the archive itself.
@@ -14,6 +14,7 @@
  */
 import path from 'path'
 import raf from 'random-access-file'
+import rafReadOnly from './raf-readonly'
 import ram from 'random-access-memory'
 import multi from 'multi-random-access'
 import messages from 'append-tree/messages'
@@ -100,13 +101,13 @@ function createStorage(archive, dir) {
   }
 
   function file(name, opts={}) {
-    let directory = '.'
     if (opts.path) {
       const parsed = path.parse(opts.path)
       name = parsed.base
-      directory = parsed.dir
+      return rafReadOnly(name, {directory: parsed.dir})
+    } else {
+      return raf(name, {directory: '.'})
     }
-    return raf(name, {directory})
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/tom-james-watson/dat-cp/issues/14

Previously, raf would try and write the file to disk when adding a file
to an archive, regardless of the fact that the file already exists on
disk.